### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btrfs-diskformat"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Christopher Tam <ohgodtamit@gmail.com>"]
 edition = "2018"
 description = "An implementation of the BTRFS disk format."
@@ -11,9 +11,9 @@ keywords = ["btrfs", "filesystem", "diskformat"]
 categories = ["filesystem"]
 
 [dependencies]
-byteorder = "1.3.4"
+byteorder = "1.4.3"
 bitflags = "1.2.1"
 num_enum = "0.5.1"
 static_assertions = "1.1.0"
 strum = { version = "0.20", features = ["derive"] }
-zerocopy = "0.3.0"
+zerocopy = "0.4.0"

--- a/src/core/super_block.rs
+++ b/src/core/super_block.rs
@@ -127,10 +127,7 @@ pub struct SuperBlock {
 
     pub super_roots: [RootBackup; NUM_BACKUP_ROOTS],
 
-    // FIXME(const_generics): Merge unused arrays into one array when const_generics is stabilized
-    // and zerocopy uses generics to implement traits.
-    pub _unused1: [u8; 512],
-    pub _unused2: [u8; 53],
+    pub _unused1: [u8; 565],
 }
 const_assert_eq!(std::mem::size_of::<SuperBlock>(), 4096);
 


### PR DESCRIPTION
This change should land once rustc 1.51 becomes stable, since this change bumps zerocopy to 0.4.0, which requires const generics.