### PR TITLE
Refactor dependencies for `#![no_std]` compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ byteorder = { version = "^1.4.3", default-features = false }
 bitflags = "^1.3"
 num_enum = { version = "^0.5", default-features = false }
 static_assertions = "^1.1.0"
-strum = { version = "^0.24.1", features = ["derive"], default-features = false }
-zerocopy = "^0.6.1"
+strum = { version = "^0.23", features = ["derive"], default-features = false }
+zerocopy = "^0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ keywords = ["btrfs", "filesystem", "diskformat"]
 categories = ["filesystem", "no-std"]
 
 [dependencies]
-byteorder = "^1.4.3"
+byteorder = { version = "^1.4.3", default-features = false }
 bitflags = "^1.3"
-num_enum = "^0.5"
+num_enum = { version = "^0.5", default-features = false }
 static_assertions = "^1.1.0"
-strum = { version = "^0.23", features = ["derive"] }
-zerocopy = "^0.4.0"
+strum = { version = "^0.24.1", features = ["derive"], default-features = false }
+zerocopy = "^0.6.1"


### PR DESCRIPTION
Three of the crates depended upon ― `byteorder`, `num_enum`, and `strum` respectively ― need to have `default-features = false` applied in order for this crate to actually be `#![no_std]` compatible. These dependency crates try to pull in `std` ― breaking any usage of this crate in `#![no_std]` environments by so doing ― by default if this is not specified.