### PR TITLE
Migrate to latest versions of dependencies

### DIFF
--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -39,3 +39,6 @@ jobs:
 
       - name: Check formatting
         run: cargo fmt --check
+
+      - name: Run lints
+        run: cargo clippy -- -D clippy::all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "btrfs-diskformat"
 version = "0.4.0"
 authors = ["Christopher Tam <ohgodtamit@gmail.com>"]
-edition = "2021"
+edition = "2024"
 description = "An implementation of the BTRFS disk format."
 readme = "README.md"
 repository = "https://github.com/GodTamIt/btrfs-diskformat"
@@ -10,10 +10,15 @@ license = "BSD-2-Clause"
 keywords = ["btrfs", "filesystem", "diskformat"]
 categories = ["filesystem", "no-std"]
 
+[features]
+default = []
+alloc = ["zerocopy/alloc"]
+std = ["strum/std", "zerocopy/std"]
+
 [dependencies]
-byteorder = { version = "^1.4.3", default-features = false }
-bitflags = "^1.3"
-num_enum = { version = "^0.5", default-features = false }
+bitflags = "^2.9"
+num_enum = { version = "^0.7", default-features = false }
 static_assertions = "^1.1.0"
-strum = { version = "^0.23", features = ["derive"], default-features = false }
-zerocopy = "^0.4.0"
+strum = { version = "^0.27", features = ["derive"], default-features = false }
+zerocopy = { version = "^0.8", default-features = false }
+zerocopy-derive = "^0.8"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Clean-room implementation of the [btrfs] disk format in Rust.
 
 See the [LICENSE-BSD](LICENSE-BSD) file in this repository for more information.
 
+## Cargo Features
+
+- `alloc`: Enables allocation and the `alloc` feature in `zerocopy`.
+- `std`: By default, the crate is `no_std`. This enables `std` features from
+  the `zerocopy` and `strum` dependencies.
+
 ## Contributing
 
 Because this codebase is developed without knowledge of the Linux btrfs source code and is released under a more permissive license(s) than GPLv2, development is heavily dependent on information released on the [btrfs wiki] and reverse engineering the effects of operations made by `btrfs-progs` and other utilities. As a result, contributions to this codebase must strictly follow the same siloed approach.

--- a/src/aliases.rs
+++ b/src/aliases.rs
@@ -44,7 +44,7 @@ pub type btrfs_dev_extent = DevExtent;
 // extent
 pub type btrfs_block_group_item = BlockGroupItem;
 pub type btrfs_extent_data_ref = ExtentDataRef;
-pub type btrfs_extent_inline_ref = ExtentInlineRef;
+pub type btrfs_extent_inline_ref = ExtentInlineRefHeader;
 pub type btrfs_shared_data_ref = SharedDataRef;
 
 pub const BTRFS_BLOCK_GROUP_DATA: u64 = AllocationType::DATA.bits();

--- a/src/chunk/chunk.rs
+++ b/src/chunk/chunk.rs
@@ -1,9 +1,10 @@
-use {
-    crate::Stripe,
-    byteorder::LE,
-    static_assertions::const_assert_eq,
-    zerocopy::{AsBytes, FromBytes, Unaligned, U16, U32, U64},
+use crate::Stripe;
+use static_assertions::const_assert_eq;
+use zerocopy::{
+    CastError, FromBytes as _,
+    little_endian::{U16 as U16LE, U32 as U32LE, U64 as U64LE},
 };
+use zerocopy_derive::*;
 
 /// This structure contains the mapping from a virtualized usable byte range within the backing
 /// storage to a set of one or more stripes on individual backing devices. In addition to the
@@ -13,40 +14,107 @@ use {
 /// many struct [`Stripe`] structures as specified in the [`num_stripes`] and [`sub_stripes`]
 /// fields.
 ///
+/// For the dynamically-sized version of this type with the stripes following, see [`ChunkDynamic`].
+///
 /// [`Stripe`]: crate::Stripe
 /// [`num_stripes`]: Chunk::num_stripes
 /// [`sub_stripes`]: Chunk::sub_stripes
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, Unaligned)]
+#[derive(Copy, Clone, Debug, Hash, IntoBytes, FromBytes, Unaligned, KnownLayout, Immutable)]
 #[repr(C, packed)]
 pub struct Chunk {
     /// The size of this chunk, in bytes.
-    pub length: U64<LE>,
+    pub length: U64LE,
 
     /// The object ID of the root referencing this chunk. This is always the ID of an extent root.
-    pub owner: U64<LE>,
+    pub owner: U64LE,
 
     /// The replication stripe length.
-    pub stripe_len: U64<LE>,
+    pub stripe_len: U64LE,
 
     /// Flags indicating allocation type and replication policy.
-    pub r#type: U64<LE>,
+    pub chunk_type: U64LE,
 
     /// The optimal I/O alignment for this chunk.
-    pub io_align: U32<LE>,
+    pub io_align: U32LE,
 
     /// The optimal I/O width for this chunk.
-    pub io_width: U32<LE>,
+    pub io_width: U32LE,
 
     /// The minimal I/O size for this chunk.
-    pub sector_size: U32<LE>,
+    pub sector_size: U32LE,
 
     /// The number of replication stripes.
-    pub num_stripes: U16<LE>,
+    pub num_stripes: U16LE,
 
     /// The number of sub-stripes. This is only used for RAID-10.
-    pub sub_stripes: U16<LE>,
+    ///
+    /// This is 2 for RAID-10, and 1 for all other chunk types.
+    pub sub_stripes: U16LE,
+}
+const_assert_eq!(core::mem::size_of::<Chunk>(), 48);
+
+impl Chunk {
+    /// A convenience method for converting a [`Chunk`] into a [`ChunkDynamic`].
+    ///
+    /// For a safe version, use [`ChunkDynamic::ref_from_prefix_with_elems`].
+    ///
+    /// # Safety
+    /// This function is unsafe because it assumes that the bytes following the `Chunk` structure
+    /// are valid and contain the expected number of `Stripe` structures as specified by
+    /// `num_stripes`. If this assumption is violated, it may lead to undefined behavior.
+    pub unsafe fn into_dynamic(
+        &self,
+        num_stripes: usize,
+    ) -> Result<&ChunkDynamic, CastError<&[u8], ChunkDynamic>> {
+        // This is simple arithmetic, since this is a packed structure.
+        let expected_size =
+            core::mem::size_of::<Chunk>() + num_stripes * core::mem::size_of::<Stripe>();
+
+        // Safety: We assume the bytes for `num_stripes` after the `Chunk` structure are valid, as
+        // part of the contract of this function.
+        let bytes = unsafe {
+            core::slice::from_raw_parts(self as *const Chunk as *const u8, expected_size)
+        };
+
+        ChunkDynamic::ref_from_prefix_with_elems(bytes, num_stripes).map(|(chunk, _)| chunk)
+    }
+}
+
+/// This structure contains the mapping from a virtualized usable byte range within the backing
+/// storage to a set of one or more stripes on individual backing devices. In addition to the
+/// mapping, hints on optimal I/O parameters for this chunk. It is associated with `CHUNK_ITEM`.
+///
+/// For the constant-sized version of the type, see [`Chunk`].`
+#[derive(IntoBytes, FromBytes, Unaligned, KnownLayout, Immutable)]
+#[repr(C, packed)]
+pub struct ChunkDynamic {
+    /// The size of this chunk, in bytes.
+    pub length: U64LE,
+
+    /// The object ID of the root referencing this chunk. This is always the ID of an extent root.
+    pub owner: U64LE,
+
+    /// The replication stripe length.
+    pub stripe_len: U64LE,
+
+    /// Flags indicating allocation type and replication policy.
+    pub chunk_type: U64LE,
+
+    /// The optimal I/O alignment for this chunk.
+    pub io_align: U32LE,
+
+    /// The optimal I/O width for this chunk.
+    pub io_width: U32LE,
+
+    /// The minimal I/O size for this chunk.
+    pub sector_size: U32LE,
+
+    /// The number of replication stripes.
+    pub num_stripes: U16LE,
+
+    /// The number of sub-stripes. This is only used for RAID-10.
+    pub sub_stripes: U16LE,
 
     /// The first of one or more stripes that map to device extents.
-    pub stripe: Stripe,
+    pub stripe: [Stripe],
 }
-const_assert_eq!(core::mem::size_of::<Chunk>(), 80);

--- a/src/chunk/mod.rs
+++ b/src/chunk/mod.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::module_inception)]
 mod chunk;
 mod stripe;
 

--- a/src/chunk/stripe.rs
+++ b/src/chunk/stripe.rs
@@ -1,25 +1,25 @@
-use {
-    crate::UuidBytes,
-    byteorder::LE,
-    static_assertions::const_assert_eq,
-    zerocopy::{AsBytes, FromBytes, Unaligned, U64},
-};
+use crate::UuidBytes;
+use static_assertions::const_assert_eq;
+use zerocopy::little_endian::U64 as U64LE;
+use zerocopy_derive::*;
 
 /// This structure is used to define the backing device storage that compose a
 /// [`Chunk`].
 ///
 /// [`Chunk`]: crate::Chunk
-#[derive(Copy, Clone, Debug, Hash, PartialEq, AsBytes, FromBytes, Unaligned)]
+#[derive(
+    Copy, Clone, Debug, Hash, PartialEq, IntoBytes, FromBytes, Unaligned, KnownLayout, Immutable,
+)]
 #[repr(C, packed)]
 pub struct Stripe {
     /// The ID of the device that contains this stripe.
-    pub devid: U64<LE>,
+    pub devid: U64LE,
 
     /// Location of the start of the stripe, in bytes.
     ///
     /// The length is determined by the `stripe_len` field of the associated
     /// `Chunk`.
-    pub offset: U64<LE>,
+    pub offset: U64LE,
 
     /// UUID of the device that contains this stripe.
     ///

--- a/src/core/dev_item.rs
+++ b/src/core/dev_item.rs
@@ -1,46 +1,44 @@
-use {
-    crate::UuidBytes,
-    byteorder::LE,
-    static_assertions::const_assert_eq,
-    zerocopy::{AsBytes, FromBytes, Unaligned, U32, U64},
-};
+use crate::UuidBytes;
+use static_assertions::const_assert_eq;
+use zerocopy::little_endian::{U32 as U32LE, U64 as U64LE};
+use zerocopy_derive::*;
 
 /// Represents a complete block device.
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, Unaligned)]
+#[derive(Copy, Clone, Debug, Hash, IntoBytes, FromBytes, Unaligned, KnownLayout, Immutable)]
 #[repr(C, packed)]
 pub struct DevItem {
     /// The internal btrfs device ID.
     ///
     /// This should match the devid found in the filesystem's list of devices.
-    pub devid: U64<LE>,
+    pub devid: U64LE,
 
     /// The size of the device.
-    pub total_bytes: U64<LE>,
+    pub total_bytes: U64LE,
 
     /// The bytes in use by the filesystem on the device.
-    pub bytes_used: U64<LE>,
+    pub bytes_used: U64LE,
 
     /// The optimal I/O alignment for this device.
-    pub io_align: U32<LE>,
+    pub io_align: U32LE,
 
     /// The optimal I/O width for this device.
-    pub io_width: U32<LE>,
+    pub io_width: U32LE,
 
     /// The minimum I/O size for this device.
-    pub sector_size: U32<LE>,
+    pub sector_size: U32LE,
 
     /// The type and info for this device.
-    pub r#type: U64<LE>,
+    pub dev_type: U64LE,
 
     /// The expected generation for this device.
-    pub generation: U64<LE>,
+    pub generation: U64LE,
 
     /// The starting byte of this partition on the device, to allow for stripe
     /// alignment.
-    pub start_offset: U64<LE>,
+    pub start_offset: U64LE,
 
     /// Grouping information for allocation decisions.
-    pub dev_group: U32<LE>,
+    pub dev_group: U32LE,
 
     /// The seek speed of the device on a scale from 0 to 100, where 100 is the
     /// fastest.

--- a/src/core/inode_item.rs
+++ b/src/core/inode_item.rs
@@ -1,61 +1,59 @@
-use {
-    crate::Time,
-    bitflags::bitflags,
-    byteorder::LE,
-    static_assertions::const_assert_eq,
-    zerocopy::{AsBytes, FromBytes, Unaligned, U32, U64},
-};
+use crate::Time;
+use bitflags::bitflags;
+use static_assertions::const_assert_eq;
+use zerocopy::little_endian::{U32 as U32LE, U64 as U64LE};
+use zerocopy_derive::*;
 
 /// Contains traditional inode data and attributes.
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, Unaligned)]
+#[derive(Copy, Clone, Debug, Hash, IntoBytes, FromBytes, Unaligned, KnownLayout, Immutable)]
 #[repr(C, packed)]
 pub struct InodeItem {
     // FIXME: add documentation!
-    pub generation: U64<LE>,
+    pub generation: U64LE,
 
     // FIXME: add documentation!
-    pub transid: U64<LE>,
+    pub transid: U64LE,
 
     /// The size of a file, in bytes.
-    pub size: U64<LE>,
+    pub size: U64LE,
 
     /// The size allocated to the file, in bytes.
     ///
     /// This is equal to the sum of all of the extent data for the inode.
     /// This is 0 for directories.
-    pub nbytes: U64<LE>,
+    pub nbytes: U64LE,
 
     /// This contains the byte offset of a block group when structure is a free space inode.
     ///
     /// This value is unused for normal inodes.
-    pub block_group: U64<LE>,
+    pub block_group: U64LE,
 
     /// Count of inode references for the inode.
     ///
     /// When used outside of a file tree, this value is 1.
-    pub nlink: U32<LE>,
+    pub nlink: U32LE,
 
     /// The user ID of the owner in Unix.
-    pub uid: U32<LE>,
+    pub uid: U32LE,
 
     /// The group ID of the group owner in Unix.
-    pub gid: U32<LE>,
+    pub gid: U32LE,
 
     /// The Unix protection mode.
-    pub mode: U32<LE>,
+    pub mode: U32LE,
 
     /// The device identifier (if a special file).
-    pub rdev: U64<LE>,
+    pub rdev: U64LE,
 
     /// Flags for the inode. See [InodeFlags] for values.
-    pub flags: U64<LE>,
+    pub flags: U64LE,
 
     /// A sequence number used for compatibility with NFS.
     ///
     /// This value is initialized to 0 and incremented each time [mtime] is updated.
     ///
     /// [mtime]: InodeItem::mtime
-    pub sequence: U64<LE>,
+    pub sequence: U64LE,
 
     pub _unused: [u64; 4],
 

--- a/src/core/key.rs
+++ b/src/core/key.rs
@@ -1,15 +1,13 @@
-use {
-    byteorder::LE,
-    static_assertions::const_assert_eq,
-    zerocopy::{AsBytes, FromBytes, Unaligned, U64},
-};
+use static_assertions::const_assert_eq;
+use zerocopy::little_endian::U64 as U64LE;
+use zerocopy_derive::*;
 
 /// A key used to describe and locate any item in any tree.
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, Unaligned)]
+#[derive(Copy, Clone, Debug, IntoBytes, FromBytes, Unaligned, KnownLayout, Immutable)]
 #[repr(C, packed)]
 pub struct Key {
-    pub objectid: U64<LE>,
-    pub r#type: u8,
-    pub offset: U64<LE>,
+    pub objectid: U64LE,
+    pub key_type: u8,
+    pub offset: U64LE,
 }
 const_assert_eq!(core::mem::size_of::<Key>(), 17);

--- a/src/core/root_backup.rs
+++ b/src/core/root_backup.rs
@@ -1,37 +1,35 @@
-use {
-    byteorder::LE,
-    static_assertions::const_assert_eq,
-    zerocopy::{AsBytes, FromBytes, Unaligned, U64},
-};
+use static_assertions::const_assert_eq;
+use zerocopy::little_endian::U64 as U64LE;
+use zerocopy_derive::*;
 
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, Unaligned)]
+#[derive(Copy, Clone, Debug, FromBytes, IntoBytes, Unaligned, KnownLayout)]
 #[repr(C, packed)]
 pub struct RootBackup {
-    pub tree_root: U64<LE>,
-    pub tree_root_gen: U64<LE>,
+    pub tree_root: U64LE,
+    pub tree_root_gen: U64LE,
 
-    pub chunk_root: U64<LE>,
-    pub chunk_root_gen: U64<LE>,
+    pub chunk_root: U64LE,
+    pub chunk_root_gen: U64LE,
 
-    pub extent_root: U64<LE>,
-    pub extent_root_gen: U64<LE>,
+    pub extent_root: U64LE,
+    pub extent_root_gen: U64LE,
 
-    pub fs_root: U64<LE>,
-    pub fs_root_gen: U64<LE>,
+    pub fs_root: U64LE,
+    pub fs_root_gen: U64LE,
 
-    pub dev_root: U64<LE>,
-    pub dev_root_gen: U64<LE>,
+    pub dev_root: U64LE,
+    pub dev_root_gen: U64LE,
 
-    pub csum_root: U64<LE>,
-    pub csum_root_gen: U64<LE>,
+    pub csum_root: U64LE,
+    pub csum_root_gen: U64LE,
 
-    pub total_bytes: U64<LE>,
-    pub bytes_used: U64<LE>,
+    pub total_bytes: U64LE,
+    pub bytes_used: U64LE,
 
-    pub num_devices: U64<LE>,
+    pub num_devices: U64LE,
 
     /// Reserved for future use.
-    pub _unused_u64s: [U64<LE>; 4],
+    pub _unused_u64s: [u64; 4],
 
     pub tree_root_level: u8,
 

--- a/src/core/root_item.rs
+++ b/src/core/root_item.rs
@@ -1,35 +1,33 @@
-use {
-    crate::{InodeItem, Key, Time, UuidBytes},
-    byteorder::LE,
-    static_assertions::const_assert_eq,
-    zerocopy::{AsBytes, FromBytes, Unaligned, U32, U64},
-};
+use crate::{InodeItem, Key, Time, UuidBytes};
+use static_assertions::const_assert_eq;
+use zerocopy::little_endian::{U32 as U32LE, U64 as U64LE};
+use zerocopy_derive::*;
 
 /// Defines the location and parameters of the root of a b-tree.
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, Unaligned)]
+#[derive(Copy, Clone, Debug, IntoBytes, FromBytes, Unaligned, KnownLayout)]
 #[repr(C, packed)]
 pub struct RootItem {
     pub inode: InodeItem,
 
-    pub generation: U64<LE>,
+    pub generation: U64LE,
 
-    pub root_dirid: U64<LE>,
+    pub root_dirid: U64LE,
 
-    pub bytenr: U64<LE>,
+    pub bytenr: U64LE,
 
     /// Currently unused. Always 0.
-    pub byte_limit: U64<LE>,
+    pub byte_limit: U64LE,
 
     /// Currently unused.
-    pub bytes_used: U64<LE>,
+    pub bytes_used: U64LE,
 
     /// The transaction ID of the last transaction that created a snapshot of this root.
-    pub last_snapshot: U64<LE>,
+    pub last_snapshot: U64LE,
 
-    pub flags: U64<LE>,
+    pub flags: U64LE,
 
     /// Only 0 or 1. Historically contained a reference count.
-    pub refs: U32<LE>,
+    pub refs: U32LE,
 
     /// Contains the key of the last dropped item during subvolume removal or relocation.
     ///
@@ -49,7 +47,7 @@ pub struct RootItem {
     /// the fields are invalid but recoverable.
     ///
     /// [generation]: RootItem::generation
-    pub generation_v2: U64<LE>,
+    pub generation_v2: U64LE,
 
     /// The subvolume's UUID.
     pub uuid: UuidBytes,
@@ -67,20 +65,20 @@ pub struct RootItem {
     /// The transaction ID of the last transaction that modified the tree.
     ///
     /// Note: some operations like internal caches or relocation will not update this value.
-    pub ctransid: U64<LE>,
+    pub ctransid: U64LE,
 
     /// The transaction ID of the transaction that created the tree.
-    pub otransid: U64<LE>,
+    pub otransid: U64LE,
 
     /// The transaction ID for the transaction that sent this subvolume.
     ///
     /// This value is non-zero for a received subvolume.
-    pub stransid: U64<LE>,
+    pub stransid: U64LE,
 
     /// The transaction ID for the transaction that received this subvolume.
     ///
     /// This value is non-zero for a received subvolume.
-    pub rtransid: U64<LE>,
+    pub rtransid: U64LE,
 
     /// The timestamp of the [`ctransid`](RootItem::ctransid).
     pub ctime: Time,

--- a/src/core/root_ref.rs
+++ b/src/core/root_ref.rs
@@ -1,23 +1,21 @@
-use {
-    byteorder::LE,
-    static_assertions::const_assert_eq,
-    zerocopy::{AsBytes, FromBytes, Unaligned, U16, U64},
-};
+use static_assertions::const_assert_eq;
+use zerocopy::little_endian::{U16 as U16LE, U64 as U64LE};
+use zerocopy_derive::*;
 
 /// References a subvolume filesystem tree root. This is used for both forward and
 /// backward root references.
 ///
 /// The name of the tree is stored after the end of the struct.
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, Unaligned)]
+#[derive(Copy, Clone, Debug, IntoBytes, FromBytes, Unaligned, KnownLayout)]
 #[repr(C, packed)]
 pub struct RootRef {
     /// The subtree ID.
-    pub dirid: U64<LE>,
+    pub dirid: U64LE,
 
     /// The directory sequence number of the subtree entry.
-    pub sequence: U64<LE>,
+    pub sequence: U64LE,
 
     /// The length of the subtree name, stored after this field.
-    pub name_len: U16<LE>,
+    pub name_len: U16LE,
 }
 const_assert_eq!(core::mem::size_of::<RootRef>(), 18);

--- a/src/core/time.rs
+++ b/src/core/time.rs
@@ -1,19 +1,30 @@
-use {
-    byteorder::LE,
-    static_assertions::const_assert_eq,
-    zerocopy::{AsBytes, FromBytes, Unaligned, I64, U32},
-};
+use static_assertions::const_assert_eq;
+use zerocopy::little_endian::{I64 as I64LE, U32 as U32LE};
+use zerocopy_derive::*;
 
 /// The layout of timestamps on disk.
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, Unaligned)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Hash,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    IntoBytes,
+    FromBytes,
+    Unaligned,
+    KnownLayout,
+    Immutable,
+)]
 #[repr(C, packed)]
 pub struct Time {
     /// The timestamp using Unix time convention.
-    pub timestamp: I64<LE>,
+    pub timestamp: I64LE,
 
     /// The number of nanoseconds past the beginning of the second denoted in [timestamp].
     ///
     /// [timestamp]: Time::timestamp
-    pub nanoseconds: U32<LE>,
+    pub nanoseconds: U32LE,
 }
 const_assert_eq!(core::mem::size_of::<Time>(), 12);

--- a/src/dev/dev_extent.rs
+++ b/src/dev/dev_extent.rs
@@ -1,29 +1,27 @@
-use {
-    crate::types::UuidBytes,
-    byteorder::LE,
-    static_assertions::const_assert_eq,
-    zerocopy::{AsBytes, FromBytes, Unaligned, U64},
-};
+use crate::types::UuidBytes;
+use static_assertions::const_assert_eq;
+use zerocopy::little_endian::U64 as U64LE;
+use zerocopy_derive::*;
 
 /// Maps physical extents on an individual backing device to a chunk. This extent
 /// may be the only one for a particular chunk or one of several.
 ///
 /// It is associated with the `DEV_ITEM` item. This structure is never used
 /// outside of this item.
-#[derive(Clone, Debug, AsBytes, FromBytes, Unaligned)]
+#[derive(Clone, Debug, Hash, IntoBytes, FromBytes, Unaligned, KnownLayout, Immutable)]
 #[repr(C, packed)]
 pub struct DevExtent {
     /// The object ID of the chunk tree that owns this extent.
-    pub chunk_tree: U64<LE>,
+    pub chunk_tree: U64LE,
 
     /// The object ID of the chunk item that references this extent.
-    pub chunk_objectid: U64<LE>,
+    pub chunk_objectid: U64LE,
 
     /// The offset of the chunk item that references this extent.
-    pub chunk_offset: U64<LE>,
+    pub chunk_offset: U64LE,
 
     /// The length of this extent, in bytes.
-    pub length: U64<LE>,
+    pub length: U64LE,
 
     /// The UUID of the chunk tree that owns this extent.
     pub chunk_tree_uuid: UuidBytes,

--- a/src/extent/block_group_item.rs
+++ b/src/extent/block_group_item.rs
@@ -1,22 +1,20 @@
-use {
-    bitflags::bitflags,
-    byteorder::LE,
-    static_assertions::const_assert_eq,
-    zerocopy::{AsBytes, FromBytes, Unaligned, U64},
-};
+use bitflags::bitflags;
+use static_assertions::const_assert_eq;
+use zerocopy::little_endian::U64 as U64LE;
+use zerocopy_derive::*;
 
 /// Defines the location, properties, and usage of a block group.
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, Unaligned)]
+#[derive(Copy, Clone, Debug, Hash, IntoBytes, FromBytes, Unaligned, KnownLayout, Immutable)]
 #[repr(C, packed)]
 pub struct BlockGroupItem {
     /// The space used, in bytes, in this block group.
-    pub used: U64<LE>,
+    pub used: U64LE,
 
     /// The object ID of the chunk backing this block group.
-    pub chunk_objectid: U64<LE>,
+    pub chunk_objectid: U64LE,
 
     /// Flags indicating allocation type and replication policy.
-    pub flags: U64<LE>,
+    pub flags: U64LE,
 }
 const_assert_eq!(core::mem::size_of::<BlockGroupItem>(), 24);
 

--- a/src/extent/extent_data_ref.rs
+++ b/src/extent/extent_data_ref.rs
@@ -1,27 +1,25 @@
-use {
-    byteorder::LE,
-    static_assertions::const_assert_eq,
-    zerocopy::{AsBytes, FromBytes, Unaligned, U32, U64},
-};
+use static_assertions::const_assert_eq;
+use zerocopy::little_endian::{U32 as U32LE, U64 as U64LE};
+use zerocopy_derive::*;
 
 /// Contains an indirect back reference for a file data extent.
 ///
 /// Immediately follows an [`ExtentInlineRef`]. See that documentation for more details.
 ///
 /// [`ExtentInlineRef`]: crate::ExtentInlineRef
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, Unaligned)]
+#[derive(Copy, Clone, Debug, Hash, IntoBytes, FromBytes, Unaligned, KnownLayout, Immutable)]
 #[repr(C, packed)]
 pub struct ExtentDataRef {
     /// The object ID for the file tree that references this extent.
-    pub root: U64<LE>,
+    pub root: U64LE,
 
     /// The object ID of the inode that contains the extent data that references this extent.
-    pub objectid: U64<LE>,
+    pub objectid: U64LE,
 
     /// The offset within the file that corresponds to this extent.
-    pub offset: U64<LE>,
+    pub offset: U64LE,
 
     /// The reference count being held.
-    pub count: U32<LE>,
+    pub count: U32LE,
 }
 const_assert_eq!(core::mem::size_of::<ExtentDataRef>(), 28);

--- a/src/extent/extent_inline_ref.rs
+++ b/src/extent/extent_inline_ref.rs
@@ -1,41 +1,294 @@
-use {
-    byteorder::LE,
-    num_enum::{IntoPrimitive, TryFromPrimitive},
-    static_assertions::const_assert_eq,
-    strum::EnumIter,
-    zerocopy::{AsBytes, FromBytes, Unaligned, U64},
-};
+use crate::{ExtentDataRef, SharedDataRef};
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+use static_assertions::{const_assert, const_assert_eq};
+use strum::EnumIter;
+use zerocopy::little_endian::U64 as U64LE;
+use zerocopy_derive::*;
 
 /// This acts as a header for different types of inline extent back references inside extent or
 /// metadata items.
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, Unaligned)]
+///
+/// For the full version that contains a union of all possible inline extent references, see
+/// [`ExtentInlineRefFull`]. That type may be more convenient if you are reading the entire
+/// reference from disk at once to save trips to disk.
+///
+/// [`ExtentInlineRefFull`]: crate::ExtentInlineRefFull
+#[derive(Copy, Clone, Debug, Hash, TryFromBytes, IntoBytes, Unaligned, KnownLayout, Immutable)]
 #[repr(C, packed)]
-pub struct ExtentInlineRef {
+pub struct ExtentInlineRefHeader {
     /// The type of reference, which corresponds with a value from [`ExtentInlineRefType`].
     /// This field also determines the semantic importance of [`offset`].
     ///
     /// [`ExtentInlineRefType`]: crate::ExtentInlineRefType
     /// [`offset`]: ExtentInlineRef::offset
-    pub r#type: u8,
+    pub ref_type: ExtentInlineRefType,
 
-    /// This field has different functions depending on the value of [`type`].
+    /// This field has different functions depending on the value of [`ref_type`].
     ///
-    /// [`type`]: ExtentInlineRef::type
-    pub offset: U64<LE>,
+    /// [`ref_type`]: ExtentInlineRef::ref_type
+    pub offset: U64LE,
 }
-const_assert_eq!(core::mem::size_of::<ExtentInlineRef>(), 9);
+const_assert_eq!(core::mem::size_of::<ExtentInlineRefHeader>(), 9);
 
-/// The type of [`ExtentInlineRef`].
+/// This type contains a union of all possible inline extent references. Using this can be helpful
+/// when an entire inline reference is read from disk to save trips to the disk but the type of
+/// the reference is not known in advance.
 ///
-/// [`ExtentInlineRef`]: crate::ExtentInlineRef
-#[derive(Copy, Clone, Debug, Hash, PartialEq, EnumIter, IntoPrimitive, TryFromPrimitive)]
+/// For the header-only version, see [`ExtentInlineRefHeader`].
+#[derive(Copy, Clone, TryFromBytes, Unaligned, KnownLayout, Immutable)]
+#[repr(C, packed)]
+pub struct ExtentInlineRefFull {
+    /// This should be equal to [`ExtentInlineRefType::ExtentDataRef`].
+    pub ref_type: ExtentInlineRefType,
+
+    /// This field has different functions depending on the value of [`ref_type`].
+    ///
+    /// [`ref_type`]: ExtentInlineRef::ref_type
+    pub tail: ExtentInlineRefTail,
+}
+const_assert_eq!(core::mem::size_of::<ExtentInlineRefFull>(), 29);
+
+impl ExtentInlineRefFull {
+    /// Returns the value of the offset field, if it is valid for the given [`ref_type`].
+    ///
+    /// [`ref_type`]: Self::ref_type
+    pub fn offset(&self) -> Option<u64> {
+        match self.ref_type {
+            ExtentInlineRefType::TreeBlockRef | ExtentInlineRefType::SharedBlockRef => {
+                Some(unsafe { self.tail.offset.get() })
+            }
+            ExtentInlineRefType::SharedDataRef => {
+                Some(unsafe { self.tail.shared_data_tail.offset.get() })
+            }
+            _ => None,
+        }
+    }
+
+    /// Returns the extent data reference if the reference type is
+    /// [`ExtentInlineRefType::ExtentDataRef`].
+    pub fn extent_data_ref(&self) -> Option<ExtentDataRef> {
+        if self.ref_type == ExtentInlineRefType::ExtentDataRef {
+            Some(unsafe { self.tail.extent_data_ref })
+        } else {
+            None
+        }
+    }
+
+    /// Returns the shared data tail if the reference type is
+    /// [`ExtentInlineRefType::SharedDataRef`].
+    pub fn shared_data_tail(&self) -> Option<ExtentInlineRefSharedDataTail> {
+        if self.ref_type == ExtentInlineRefType::SharedDataRef {
+            Some(unsafe { self.tail.shared_data_tail })
+        } else {
+            None
+        }
+    }
+
+    pub fn as_tree_block_ref(&self) -> Option<&ExtentInlineTreeBlockRef> {
+        const_assert!(
+            core::mem::size_of::<ExtentInlineRefFull>()
+                >= core::mem::size_of::<ExtentInlineTreeBlockRef>()
+        );
+
+        if self.ref_type == ExtentInlineRefType::TreeBlockRef {
+            // Safety: We know that the bytes are valid for `ExtentInlineTreeBlockRef` because
+            // `ref_type` is `ExtentInlineRefType::TreeBlockRef`.
+            Some(unsafe {
+                &*(self as *const ExtentInlineRefFull as *const ExtentInlineTreeBlockRef)
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn as_shared_block_ref(&self) -> Option<&ExtentInlineSharedBlockRef> {
+        const_assert!(
+            core::mem::size_of::<ExtentInlineRefFull>()
+                >= core::mem::size_of::<ExtentInlineSharedBlockRef>()
+        );
+
+        if self.ref_type == ExtentInlineRefType::SharedBlockRef {
+            // Safety: We know that the bytes are valid for `ExtentInlineSharedBlockRef` because
+            // `ref_type` is `ExtentInlineRefType::SharedBlockRef`.
+            Some(unsafe {
+                &*(self as *const ExtentInlineRefFull as *const ExtentInlineSharedBlockRef)
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn as_extent_data_ref(&self) -> Option<&ExtentInlineExtentDataRef> {
+        const_assert!(
+            core::mem::size_of::<ExtentInlineRefFull>()
+                >= core::mem::size_of::<ExtentInlineExtentDataRef>()
+        );
+
+        if self.ref_type == ExtentInlineRefType::ExtentDataRef {
+            // Safety: We know that the bytes are valid for `ExtentInlineExtentDataRef` because
+            // `ref_type` is `ExtentInlineRefType::ExtentDataRef`.
+            Some(unsafe {
+                &*(self as *const ExtentInlineRefFull as *const ExtentInlineExtentDataRef)
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn as_shared_data_ref(&self) -> Option<&ExtentInlineSharedDataRef> {
+        const_assert!(
+            core::mem::size_of::<ExtentInlineRefFull>()
+                >= core::mem::size_of::<ExtentInlineSharedDataRef>()
+        );
+
+        if self.ref_type == ExtentInlineRefType::SharedDataRef {
+            // Safety: We know that the bytes are valid for `ExtentInlineSharedDataRef` because
+            // `ref_type` is `ExtentInlineRefType::SharedDataRef`.
+            Some(unsafe {
+                &*(self as *const ExtentInlineRefFull as *const ExtentInlineSharedDataRef)
+            })
+        } else {
+            None
+        }
+    }
+}
+
+/// Union that contains the actual data for the inline extent reference.
+#[derive(Copy, Clone, FromBytes, Unaligned, KnownLayout, Immutable)]
+#[repr(C, packed)]
+pub union ExtentInlineRefTail {
+    pub offset: U64LE,
+    pub extent_data_ref: ExtentDataRef,
+    pub shared_data_tail: ExtentInlineRefSharedDataTail,
+}
+
+/// A variant of [`ExtentInlineRefTail`] for [`ExtentInlineRefType::SharedDataRef`].
+#[derive(Copy, Clone, Debug, Hash, FromBytes, IntoBytes, Unaligned, KnownLayout, Immutable)]
+#[repr(C, packed)]
+pub struct ExtentInlineRefSharedDataTail {
+    /// The byte offset of the metadata that contains the extent data item that describes this
+    /// extent.
+    pub offset: U64LE,
+
+    /// The shared data reference count.
+    pub shared_data_ref: SharedDataRef,
+}
+
+/// An [`ExtentInlineRefHeader`] and/or [`ExtentInlineRefFull`] where the value is known to be
+/// [`ExtentInlineRefType::TreeBlockRef`].
+#[derive(Copy, Clone, Debug, Hash, TryFromBytes, IntoBytes, Unaligned, KnownLayout, Immutable)]
+#[repr(C, packed)]
+pub struct ExtentInlineTreeBlockRef {
+    /// This is here to allow [`TryFromBytes`] to enforce the type of the reference.
+    ref_type: ExtentInlineTreeBlockRefType,
+
+    /// The object ID of the tree root that allocated the block.
+    pub offset: U64LE,
+}
+
+#[derive(Copy, Clone, Debug, Hash, PartialEq, TryFromBytes, IntoBytes, KnownLayout, Immutable)]
+#[repr(u8)]
+enum ExtentInlineTreeBlockRefType {
+    #[allow(dead_code)]
+    TreeBlockRef = ExtentInlineRefType::TreeBlockRef as u8,
+}
+const_assert_eq!(
+    core::mem::size_of::<ExtentInlineTreeBlockRefType>(),
+    core::mem::size_of::<ExtentInlineRefType>()
+);
+
+/// An [`ExtentInlineRefHeader`] and/or [`ExtentInlineRefFull`] where the value is known to be
+/// [`ExtentInlineRefType::SharedBlockRef`].
+#[derive(Copy, Clone, Debug, Hash, TryFromBytes, IntoBytes, Unaligned, KnownLayout, Immutable)]
+#[repr(C, packed)]
+pub struct ExtentInlineSharedBlockRef {
+    /// This is here to allow [`TryFromBytes`] to enforce the type of the reference.
+    ref_type: ExtentInlineSharedBlockRefType,
+
+    /// The byte offset of the node one level above in the tree where this block is located.
+    pub offset: U64LE,
+}
+
+#[derive(Copy, Clone, Debug, Hash, PartialEq, TryFromBytes, IntoBytes, KnownLayout, Immutable)]
+#[repr(u8)]
+#[allow(dead_code)]
+enum ExtentInlineSharedBlockRefType {
+    SharedBlockRef = ExtentInlineRefType::SharedBlockRef as u8,
+}
+
+/// An [`ExtentInlineRefHeader`] and/or [`ExtentInlineRefFull`] where the value is known to be
+/// [`ExtentInlineRefType::ExtentDataRef`].
+#[derive(Copy, Clone, Debug, Hash, TryFromBytes, IntoBytes, Unaligned, KnownLayout, Immutable)]
+#[repr(C, packed)]
+pub struct ExtentInlineExtentDataRef {
+    /// This is here to allow [`TryFromBytes`] to enforce the type of the reference.
+    ref_type: ExtentInlineExtentDataRefType,
+
+    /// The extent data reference that overlaps the unused offset field.
+    pub extent_data_ref: ExtentDataRef,
+}
+
+#[derive(Copy, Clone, Debug, Hash, PartialEq, TryFromBytes, IntoBytes, KnownLayout, Immutable)]
+#[repr(u8)]
+enum ExtentInlineExtentDataRefType {
+    #[allow(dead_code)]
+    ExtentDataRef = ExtentInlineRefType::ExtentDataRef as u8,
+}
+const_assert_eq!(
+    core::mem::size_of::<ExtentInlineExtentDataRefType>(),
+    core::mem::size_of::<ExtentInlineRefType>()
+);
+
+/// An [`ExtentInlineRefHeader`] and/or [`ExtentInlineRefFull`] where the value is known to be
+/// [`ExtentInlineRefType::SharedDataRef`].
+#[derive(Copy, Clone, Debug, Hash, TryFromBytes, IntoBytes, Unaligned, KnownLayout, Immutable)]
+#[repr(C, packed)]
+pub struct ExtentInlineSharedDataRef {
+    /// This is here to allow [`TryFromBytes`] to enforce the type of the reference.
+    ref_type: ExtentInlineSharedDataRefType,
+
+    /// The tail of a shared data reference that contains the byte offset of the metadata that
+    /// contains the extent data item that describes this extent and the shared data reference
+    /// count.
+    pub shared_data_tail: ExtentInlineRefSharedDataTail,
+}
+
+#[derive(Copy, Clone, Debug, Hash, PartialEq, TryFromBytes, IntoBytes, KnownLayout, Immutable)]
+#[repr(u8)]
+enum ExtentInlineSharedDataRefType {
+    #[allow(dead_code)]
+    SharedDataRef = ExtentInlineRefType::SharedDataRef as u8,
+}
+const_assert_eq!(
+    core::mem::size_of::<ExtentInlineSharedDataRefType>(),
+    core::mem::size_of::<ExtentInlineRefType>()
+);
+
+/// The type of [`ExtentInlineRefHeader`] or [`ExtentInlineRefFull`].
+///
+/// [`ExtentInlineRefHeader`]: crate::ExtentInlineRefHeader
+/// [`ExtentInlineRefFull`]: crate::ExtentInlineRefFull
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Hash,
+    PartialEq,
+    EnumIter,
+    IntoPrimitive,
+    TryFromPrimitive,
+    TryFromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+)]
 #[repr(u8)]
 pub enum ExtentInlineRefType {
     /// The reference is indirect for a tree block.
     ///
     /// [`offset`] contains the object ID of the tree root that allocated the block.
     ///
-    /// [`offset`]: ExtentInlineRef::offset
+    /// [`offset`]: ExtentInlineRefHeader::offset
     TreeBlockRef = 176,
 
     /// The reference is shared for a tree block.
@@ -43,16 +296,16 @@ pub enum ExtentInlineRefType {
     /// [`offset`] contains the byte offset of the node one level above in the tree where this block
     /// is located.
     ///
-    /// [`offset`]: ExtentInlineRef::offset
+    /// [`offset`]: ExtentInlineRefHeader::offset
     SharedBlockRef = 182,
 
     /// The reference is indirect for a data extent.
     ///
-    /// An `ExtentDataRef` is located immediately after the [`type`] field and overlaps the unused
+    /// An [`ExtentDataRef`] is located immediately after the [`type`] field and overlaps the unused
     /// [`offset`] field.
     ///
     /// [`type`]: ExtentInlineRef::type
-    /// [`offset`]: ExtentInlineRef::offset
+    /// [`offset`]: ExtentInlineRefHeader::offset
     ExtentDataRef = 178,
 
     /// The reference is shared for a data extent.
@@ -60,11 +313,9 @@ pub enum ExtentInlineRefType {
     /// [`offset`] contains the byte offset of the metadata that contains the extent data item that
     /// describes this extent.
     ///
-    /// Immediately following [`offset`] (and the end of [`ExtentInlineRef`] structure) is a
+    /// Immediately following [`offset`] (and the end of [`ExtentInlineRefHeader`] structure) is a
     /// [`SharedDataRef`] that contains the reference count.
     ///
-    /// [`offset`]: ExtentInlineRef::offset
-    /// [`ExtentInlineRef`]: crate::ExtentInlineRef
-    /// [`SharedDataRef`]: crate::SharedDataRef
+    /// [`offset`]: ExtentInlineRefHeader::offset
     SharedDataRef = 184,
 }

--- a/src/extent/shared_data_ref.rs
+++ b/src/extent/shared_data_ref.rs
@@ -1,19 +1,18 @@
-use {
-    byteorder::LE,
-    static_assertions::const_assert_eq,
-    zerocopy::{AsBytes, FromBytes, Unaligned, U32},
-};
+use static_assertions::const_assert_eq;
+use zerocopy::little_endian::U32 as U32LE;
+use zerocopy_derive::*;
 
 /// This structure contains the reference count for a shared back reference for a file data extent.
 ///
-/// This immediately follows an [`ExtentInlineRef`] of type [`SharedDataRef`] inside an extent item.
+/// This immediately follows an [`ExtentInlineRefHeader`] of type [`SharedDataRef`] inside an extent
+/// item.
 ///
-/// [`ExtentInlineRef`]: crate::ExtentInlineRef
+/// [`ExtentInlineRefHeader`]: crate::ExtentInlineRefHeader
 /// [`SharedDataRef`]: crate::ExtentInlineRefType::SharedDataRef
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, Unaligned)]
+#[derive(Copy, Clone, Debug, Hash, IntoBytes, FromBytes, Unaligned, KnownLayout, Immutable)]
 #[repr(C, packed)]
 pub struct SharedDataRef {
     /// The reference count.
-    pub count: U32<LE>,
+    pub count: U32LE,
 }
 const_assert_eq!(core::mem::size_of::<SharedDataRef>(), 4);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod aliases;
 pub mod constants;


### PR DESCRIPTION
This migrates the project to the latest versions of its dependencies.

Most notably, this updates to the latest `zerocopy` version and provides more types and functionality around the latest features of `zerocopy`.